### PR TITLE
reorganize a bit. Add raster-tools venv to PATH.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,12 @@ ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
-RUN pip3 install --upgrade setuptools wheel && pip3 install pip==10.0.1 pipenv==2018.5.18
 COPY . .
+
+# raster tools for line-up
+RUN pip3 install --upgrade setuptools wheel && pip3 install pip==10.0.1 pipenv==2018.5.18
 RUN git clone https://github.com/nens/raster-tools.git
 WORKDIR /code/raster-tools
 RUN git checkout emiel-hhnk
-RUN PIPENV_VENV_IN_PROJECT=1 pipenv sync --dev
+RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --dev
+ENV PATH="/code/raster-tools/.venv/bin:${PATH}"


### PR DESCRIPTION
Mostly reorganizing... The main change is in the raster-tools branch emiel-hhnk, installing another gdal version. This is because in the modelbuilder we use the ubuntugis ppa. But, here I added the path, so that you can do

docker-compose run --rm hhnk line-up -h

By the way, I ported the line-up to python3, a little bit in a hurry, so if you run into something, please report.